### PR TITLE
Mustache template bahaviour tests

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.8.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <Platforms>AnyCPU</Platforms>
+
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -102,14 +102,21 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall()
         {
             string propName = "javascriptalpha";
+            string prefixJunk = "";
+            string propSetExpr = "\"51D_alpha=\" + 42";
+            string suffixJunk = "";
+            string expectedData = "51D_alpha=42";
+
+            string propSetFlag = $"{propName}_snippet_set_block_called_51d";
             string propCode =
-                """
+                $"""
                 console.log("starting snippet");
-                document.cookie = "51D_alpha=" + 42;
-                window.alpha_set = true;
+                {prefixJunk}document.cookie = {propSetExpr}{suffixJunk}
+                ;
+                window.{propSetFlag} = true;
                 console.log("leaving snippet");
                 """;
-            string testCode = "return window.alpha_set;";
+            string testCode = $"return window.{propSetFlag};";
 
             jsonData = new() {
                 { "device", new JObject { { propName, propCode } } },
@@ -168,6 +175,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                 DumpNewLogs();
                 Thread.Sleep(1000);
             }
+            Assert.IsTrue(postData.Contains(expectedData), $"[{postData}] does not contain [{expectedData}]");
             while (!completed)
             {
                 DumpNewLogs();

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -79,7 +79,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
 
         [TestMethod]
-        [Timeout(20000)]
+        [Timeout(300_000)]
         public void JavaScriptBuilderTemplate_VerifyInterception()
         {
             bool testDone = false;
@@ -99,7 +99,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         }
 
         [DataTestMethod]
-        [Timeout(20000)]
+        [Timeout(300_000)]
         [DataRow("javascriptalpha", "", "\"51D_alpha=\" + 42", "", "51D_alpha=42")] // plain plus
         [DataRow("javascriptbeta", "if(true){", "\"51D_beta=\" + 29", "}", "51D_beta=29")] // plus in block
         [DataRow("gammajavascript", "", "\"51D_gamma=\" + \"zoomies\"", ", a=7", "51D_gamma=zoomies")] // plus in comma

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -1,0 +1,164 @@
+﻿using FiftyOne.Pipeline.Engines.TestHelpers;
+using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using OpenQA.Selenium;
+using System.Text;
+
+namespace FiftyOne.Pipeline.JavaScript.Tests
+{
+    [TestClass]
+    public class JavaScriptBuilderElementTemplateTests: JavaScriptBuilderElementTestsBase
+    {
+        private WebApplication webApp { get; set; }
+        private CancellationTokenSource webAppKillSwitch { get; set; }
+
+        [TestInitialize]
+        public override async Task Init()
+        {
+            await base.Init();
+
+            var builder = WebApplication.CreateBuilder();
+            webApp = builder.Build();
+
+            webApp.MapGet("/{*rest}", (string rest) =>
+            """
+            <!DOCTYPE>
+            <html>
+              <head>
+                <title>Test Page</title>
+              </head>
+              <body>
+              </body>
+            </html>
+            """
+            );
+
+            webApp.MapPost("/51dpipeline/json", () =>
+                "{}"
+            );
+
+            webApp.Urls.Add(ClientServerUrl);
+
+            webAppKillSwitch = new CancellationTokenSource();
+            await webApp.StartAsync(webAppKillSwitch.Token);
+        }
+
+        private static string BuildXHRJS(string dstUrl, string method = "POST", string postData = "dummy", bool acceptJson = false)
+        {
+            StringBuilder s = new();
+            s.Append("xhr = new XMLHttpRequest();");
+            s.Append($"xhr.open('{method}', '{dstUrl}', true);");
+            if (acceptJson)
+            {
+                s.Append("xmlhttp.setRequestHeader(\"Accept\", \"application/json;charset=UTF-8\");");
+            }
+            s.Append($"xhr.send('{postData}');");
+            return s.ToString();
+        }
+
+
+        [TestMethod]
+        public void JavaScriptBuilderTemplate_VerifyInterception()
+        {
+            bool testDone = false;
+            OnRequestSent = e => {
+                var p = e.RequestPostData;
+                testDone = true;
+            };
+            IJavaScriptExecutor js = Driver;
+            var q = js.ExecuteScript(BuildXHRJS($"{ClientServerUrl}/51dpipeline/json"));
+            Assert.IsTrue(testDone);
+        }
+
+        [TestMethod]
+        //[Timeout(20000)]
+        public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall()
+        {
+            string propName = "javascriptalpha";
+            string propCode = "// begin\ndocument.cookie = \"51D_alpha=\" + 42;\nalpha_set = true;\n// end\n";
+            string testCode = "alpha_set";
+
+            JObject jsonData = new() {
+                { "device", new JObject { { propName, propCode } } },
+                { "javascriptProperties", new JArray { $"device.{propName}" } },
+            };
+
+            //int firstColon = ClientServerUrl.IndexOf(":");
+            //var _javaScriptBuilderElement =
+            //    new JavaScriptBuilderElementBuilder(_loggerFactory)
+            //    .SetMinify(false)
+            //    .SetProtocol(ClientServerUrl.Substring(0, firstColon))
+            //    .SetHost(ClientServerUrl.Substring(firstColon + 3))
+            //    .Build();
+            //var flowData = new Mock<IFlowData>();
+            //Configure(flowData, jsonData);
+
+            //IJavaScriptBuilderElementData result = null;
+            //flowData.Setup(d => d.GetOrAdd(
+            //    It.IsAny<ITypedKey<IJavaScriptBuilderElementData>>(),
+            //    It.IsAny<Func<IPipeline, IJavaScriptBuilderElementData>>()))
+            //    .Returns<ITypedKey<IJavaScriptBuilderElementData>, Func<IPipeline, IJavaScriptBuilderElementData>>((k, f) =>
+            //    {
+            //        result = f(flowData.Object.Pipeline);
+            //        return result;
+            //    });
+
+            //_javaScriptBuilderElement.Process(flowData.Object);
+
+            //// JS aquired, now test
+
+            //string postData = null;
+            //bool completed = false;
+            //OnRequestSent = e =>
+            //{
+            //    if (e.RequestUrl.EndsWith("json"))
+            //    {
+            //        postData = e.RequestPostData;
+            //    }
+            //    if (e.RequestUrl.EndsWith("completed"))
+            //    {
+            //        completed = true;
+            //    }
+            //};
+            //string additionalCode
+            //    = "; fod.complete(function (data) { "
+            //    + BuildXHRJS($"{ClientServerUrl}/51dpipeline/completed")
+            //    + " });";
+
+            //IJavaScriptExecutor js = Driver;
+            //js.ExecuteScript(result.JavaScript + additionalCode);
+
+            //Assert.IsNotNull(postData);
+
+            //while (!completed)
+            //{
+            //    bool hrPrinted = false;
+            //    var entries = Driver.Manage().Logs.GetLog(LogType.Browser);
+            //    foreach (var entry in entries)
+            //    {
+            //        if (!hrPrinted)
+            //        {
+            //            Console.WriteLine("----- ----- -----");
+            //            hrPrinted = true;
+            //        }
+            //        Console.WriteLine(entry.ToString());
+            //    }
+            //    Thread.Sleep(1000);
+            //}
+
+            //var controlResult = js.ExecuteScript(testCode);
+            //Assert.IsNotNull(controlResult);
+            //Assert.IsInstanceOfType<bool>(controlResult);
+            //Assert.IsTrue((bool)controlResult);
+        }
+
+        [TestCleanup]
+        public override async Task Cleanup()
+        {
+            await base.Cleanup();
+            webAppKillSwitch.Cancel();
+            await webApp.StopAsync();
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -33,10 +33,15 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             </html>
             """
             );
-
             webApp.MapPost("/51dpipeline/json", () =>
                 "{}"
             );
+
+            webApp.Use((ctx, next) =>
+            {
+                ctx.Response.Headers["Access-Control-Allow-Origin"] = "*";
+                return next();
+            });
 
             webApp.Urls.Add(ClientServerUrl);
 
@@ -59,6 +64,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
 
         [TestMethod]
+        [Timeout(20000)]
         public void JavaScriptBuilderTemplate_VerifyInterception()
         {
             bool testDone = false;
@@ -67,7 +73,13 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                 testDone = true;
             };
             IJavaScriptExecutor js = Driver;
-            var q = js.ExecuteScript(BuildXHRJS($"{ClientServerUrl}/51dpipeline/json"));
+            var q = js.ExecuteScript(BuildXHRJS($"{ClientServerUrl}51dpipeline/json"));
+            while (!testDone)
+            {
+                DumpNewLogs();
+                Thread.Sleep(1000);
+            }
+            DumpNewLogs();
             Assert.IsTrue(testDone);
         }
 
@@ -133,17 +145,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             //while (!completed)
             //{
-            //    bool hrPrinted = false;
-            //    var entries = Driver.Manage().Logs.GetLog(LogType.Browser);
-            //    foreach (var entry in entries)
-            //    {
-            //        if (!hrPrinted)
-            //        {
-            //            Console.WriteLine("----- ----- -----");
-            //            hrPrinted = true;
-            //        }
-            //        Console.WriteLine(entry.ToString());
-            //    }
+            //    DumpNewLogs();
             //    Thread.Sleep(1000);
             //}
 
@@ -151,6 +153,21 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             //Assert.IsNotNull(controlResult);
             //Assert.IsInstanceOfType<bool>(controlResult);
             //Assert.IsTrue((bool)controlResult);
+        }
+
+        private void DumpNewLogs()
+        {
+            bool hrPrinted = false;
+            var entries = Driver.Manage().Logs.GetLog(LogType.Browser);
+            foreach (var entry in entries)
+            {
+                if (!hrPrinted)
+                {
+                    Console.WriteLine("----- ----- -----");
+                    hrPrinted = true;
+                }
+                Console.WriteLine(entry.ToString());
+            }
         }
 
         [TestCleanup]

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -97,15 +97,20 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             Assert.IsTrue(testDone);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [Timeout(20000)]
-        public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall()
+        [DataRow("javascriptalpha", "", "\"51D_alpha=\" + 42", "", "51D_alpha=42")] // plain plus
+        [DataRow("javascriptbeta", "if(true){", "\"51D_beta=\" + 29", "}", "51D_beta=29")] // plus in block
+        [DataRow("gammajavascript", "", "\"51D_gamma=\" + \"zoomies\"", ", a=7", "51D_gamma=zoomies")] // plus in comma
+        [DataRow("kappajavascript", "let q = x => x(3); q(e => ", "\"51D_kappa=\" + e", ")", "51D_kappa=3")] // plus in lambda
+        [DataRow("omegajavascript", "let q = x => x(7); q(e => ", "`51D_omega=${e}`", ")", "51D_omega=7")] // template in lambda
+        public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall(
+            string propName,
+            string prefixJunk,
+            string propSetExpr,
+            string suffixJunk,
+            string expectedData)
         {
-            string propName = "javascriptalpha";
-            string prefixJunk = "";
-            string propSetExpr = "\"51D_alpha=\" + 42";
-            string suffixJunk = "";
-            string expectedData = "51D_alpha=42";
 
             string propSetFlag = $"{propName}_snippet_set_block_called_51d";
             string propCode =

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -1,6 +1,10 @@
-﻿using FiftyOne.Pipeline.Engines.TestHelpers;
+﻿using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Core.TypedMap;
+using FiftyOne.Pipeline.JavaScriptBuilder.Data;
 using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using System.Text;
@@ -12,6 +16,8 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
     {
         private WebApplication webApp { get; set; }
         private CancellationTokenSource webAppKillSwitch { get; set; }
+        private JObject jsonData { get; set; } = new();
+        private string fullJS { get; set; } = "";
 
         [TestInitialize]
         public override async Task Init()
@@ -21,21 +27,25 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             var builder = WebApplication.CreateBuilder();
             webApp = builder.Build();
 
+            webApp.MapGet("/51dpipeline/js", () => Results.Content(fullJS, "text/javascript"));
             webApp.MapGet("/{*rest}", (string rest) =>
+            Results.Content(
             """
-            <!DOCTYPE>
+            <!DOCTYPE html>
             <html>
               <head>
                 <title>Test Page</title>
               </head>
+              <script src="/51dpipeline/js">
+              </script>
               <body>
+                Did the script already finish??
               </body>
             </html>
             """
-            );
-            webApp.MapPost("/51dpipeline/json", () =>
-                "{}"
-            );
+            , "text/html"));
+            webApp.MapPost("/51dpipeline/json", () => jsonData);
+            webApp.MapPost("/51dpipeline/completed", () => Results.Empty);
 
             webApp.Use((ctx, next) =>
             {
@@ -47,6 +57,10 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             webAppKillSwitch = new CancellationTokenSource();
             await webApp.StartAsync(webAppKillSwitch.Token);
+
+            Driver.Manage().Cookies.DeleteAllCookies();
+            // Navigate to the client site.
+            Driver.Navigate().GoToUrl(ClientServerUrl);
         }
 
         private static string BuildXHRJS(string dstUrl, string method = "POST", string postData = "dummy", bool acceptJson = false)
@@ -56,7 +70,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             s.Append($"xhr.open('{method}', '{dstUrl}', true);");
             if (acceptJson)
             {
-                s.Append("xmlhttp.setRequestHeader(\"Accept\", \"application/json;charset=UTF-8\");");
+                s.Append("xhr.setRequestHeader(\"Accept\", \"application/json;charset=UTF-8\");");
             }
             s.Append($"xhr.send('{postData}');");
             return s.ToString();
@@ -84,75 +98,94 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         }
 
         [TestMethod]
-        //[Timeout(20000)]
+        [Timeout(20000)]
         public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall()
         {
             string propName = "javascriptalpha";
-            string propCode = "// begin\ndocument.cookie = \"51D_alpha=\" + 42;\nalpha_set = true;\n// end\n";
-            string testCode = "alpha_set";
+            string propCode =
+                """
+                console.log("starting snippet");
+                document.cookie = "51D_alpha=" + 42;
+                window.alpha_set = true;
+                console.log("leaving snippet");
+                """;
+            string testCode = "return window.alpha_set;";
 
-            JObject jsonData = new() {
+            jsonData = new() {
                 { "device", new JObject { { propName, propCode } } },
                 { "javascriptProperties", new JArray { $"device.{propName}" } },
             };
 
-            //int firstColon = ClientServerUrl.IndexOf(":");
-            //var _javaScriptBuilderElement =
-            //    new JavaScriptBuilderElementBuilder(_loggerFactory)
-            //    .SetMinify(false)
-            //    .SetProtocol(ClientServerUrl.Substring(0, firstColon))
-            //    .SetHost(ClientServerUrl.Substring(firstColon + 3))
-            //    .Build();
-            //var flowData = new Mock<IFlowData>();
-            //Configure(flowData, jsonData);
+            int firstColon = ClientServerUrl.IndexOf(":");
+            var _javaScriptBuilderElement =
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
+                .SetMinify(false)
+                .SetProtocol(ClientServerUrl.Substring(0, firstColon))
+                .SetHost(ClientServerUrl.Substring(firstColon + 3))
+                .Build();
+            var flowData = new Mock<IFlowData>();
+            Configure(flowData, jsonData);
 
-            //IJavaScriptBuilderElementData result = null;
-            //flowData.Setup(d => d.GetOrAdd(
-            //    It.IsAny<ITypedKey<IJavaScriptBuilderElementData>>(),
-            //    It.IsAny<Func<IPipeline, IJavaScriptBuilderElementData>>()))
-            //    .Returns<ITypedKey<IJavaScriptBuilderElementData>, Func<IPipeline, IJavaScriptBuilderElementData>>((k, f) =>
-            //    {
-            //        result = f(flowData.Object.Pipeline);
-            //        return result;
-            //    });
+            IJavaScriptBuilderElementData result = null;
+            flowData.Setup(d => d.GetOrAdd(
+                It.IsAny<ITypedKey<IJavaScriptBuilderElementData>>(),
+                It.IsAny<Func<IPipeline, IJavaScriptBuilderElementData>>()))
+                .Returns<ITypedKey<IJavaScriptBuilderElementData>, Func<IPipeline, IJavaScriptBuilderElementData>>((k, f) =>
+                {
+                    result = f(flowData.Object.Pipeline);
+                    return result;
+                });
 
-            //_javaScriptBuilderElement.Process(flowData.Object);
+            _javaScriptBuilderElement.Process(flowData.Object);
 
-            //// JS aquired, now test
+            // JS aquired, now test
 
-            //string postData = null;
-            //bool completed = false;
-            //OnRequestSent = e =>
-            //{
-            //    if (e.RequestUrl.EndsWith("json"))
-            //    {
-            //        postData = e.RequestPostData;
-            //    }
-            //    if (e.RequestUrl.EndsWith("completed"))
-            //    {
-            //        completed = true;
-            //    }
-            //};
-            //string additionalCode
-            //    = "; fod.complete(function (data) { "
-            //    + BuildXHRJS($"{ClientServerUrl}/51dpipeline/completed")
-            //    + " });";
+            string postData = null;
+            bool completed = false;
+            OnRequestSent = e =>
+            {
+                if (e.RequestUrl.EndsWith("json"))
+                {
+                    postData = e.RequestPostData;
+                }
+                if (e.RequestUrl.EndsWith("completed"))
+                {
+                    completed = true;
+                }
+            };
+            string additionalCode
+                = "; window.onload = (e) => { fod.complete(function (data) { "
+                + BuildXHRJS($"{ClientServerUrl}51dpipeline/completed", acceptJson: true)
+                + " }); };";
 
-            //IJavaScriptExecutor js = Driver;
-            //js.ExecuteScript(result.JavaScript + additionalCode);
+            fullJS = result.JavaScript + additionalCode;
+            // Reload page to trigger script execution
+            Driver.Manage().Cookies.DeleteAllCookies();
+            Driver.Navigate().GoToUrl(ClientServerUrl);
 
-            //Assert.IsNotNull(postData);
+            while (postData == null)
+            {
+                DumpNewLogs();
+                Thread.Sleep(1000);
+            }
+            while (!completed)
+            {
+                DumpNewLogs();
+                Thread.Sleep(1000);
+            }
 
-            //while (!completed)
-            //{
-            //    DumpNewLogs();
-            //    Thread.Sleep(1000);
-            //}
-
-            //var controlResult = js.ExecuteScript(testCode);
-            //Assert.IsNotNull(controlResult);
-            //Assert.IsInstanceOfType<bool>(controlResult);
-            //Assert.IsTrue((bool)controlResult);
+            IJavaScriptExecutor js = Driver;
+            while (true)
+            {
+                var objResult = js.ExecuteScript(testCode);
+                if (objResult is bool newResult)
+                {
+                    Assert.IsTrue(newResult);
+                    break;
+                }
+                DumpNewLogs();
+                Thread.Sleep(1000);
+            };
         }
 
         private void DumpNewLogs()
@@ -166,7 +199,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                     Console.WriteLine("----- ----- -----");
                     hrPrinted = true;
                 }
-                Console.WriteLine(entry.ToString());
+                Console.WriteLine($"[BROWSER] > ${entry}");
             }
         }
 
@@ -176,6 +209,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             await base.Cleanup();
             webAppKillSwitch.Cancel();
             await webApp.StopAsync();
+            jsonData.RemoveAll();
         }
     }
 }

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -199,6 +199,12 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                 DumpNewLogs();
                 Thread.Sleep(1000);
             };
+
+            int cookieCount = Driver.Manage().Cookies.AllCookies.Count;
+            if (cookieCount > 0)
+            {
+                Assert.Inconclusive($"Detected cookies after script completion: {cookieCount}");
+            }
         }
 
         private void DumpNewLogs()

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -260,11 +260,15 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             fullJS = BuildScript(jsonData) + additionalCode;
             Assert.AreNotEqual(lastFullJS, fullJS);
 
+            string extraCookie = "51D_saved_ext=829";
+            Driver.Manage().Cookies.AddCookie(new Cookie(extraCookie.Split("=")[0], extraCookie.Split("=")[1]));
+
             // Reload page to trigger script execution
             Driver.Navigate().GoToUrl(ClientServerUrl);
 
             WaitAndValidatePostData(secondaryData.expectedData);
             WaitAndValidatePostData(mainData.expectedData);
+            WaitAndValidatePostData(extraCookie);
             WaitAndValidateScriptCompletion();
             WaitAndValidateSnippetCalled(secondaryData.testCode);
             Assert.IsNull(js.ExecuteScript(mainData.testCode));

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
@@ -27,7 +27,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using FiftyOne.Pipeline.JsonBuilder.Data;
 using FiftyOne.Pipeline.JavaScriptBuilder.Data;
-using FiftyOne.Pipeline.JsonBuilder.FlowElement;
 using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
@@ -46,7 +45,6 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
     [TestClass]
     public class JavaScriptBuilderElementTests: JavaScriptBuilderElementTestsBase
     {
-        private ILoggerFactory _loggerFactory;
         private JavaScriptBuilderElement _javaScriptBuilderElement;
 
         private HttpClient httpClient;
@@ -73,8 +71,6 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             // Navigate to the client site.
             Driver.Navigate().GoToUrl(ClientServerUrl);
-
-            _loggerFactory = new LoggerFactory();
         }
 
         /// <summary>
@@ -99,7 +95,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilderElement_JavaScript(bool minify, string key, string property, object value)
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetMinify(minify)
                 .Build();
 
@@ -140,7 +136,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilder_VerifySession()
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory).SetMinify(false).Build();
+                new JavaScriptBuilderElementBuilder(LoggerFactory).SetMinify(false).Build();
             var flowData = new Mock<IFlowData>();
             Configure(flowData);
 
@@ -169,7 +165,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilder_VerifyFallbackResponse()
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetEndpoint("/json")
                 .Build();
 
@@ -177,7 +173,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             flowData.Setup(d => d.Get<IJsonBuilderElementData>())
                 .Throws<KeyNotFoundException>();
-            var evidence = new Evidence(_loggerFactory.CreateLogger<Evidence>()); 
+            var evidence = new Evidence(LoggerFactory.CreateLogger<Evidence>()); 
             flowData.Setup(d => d.GetEvidence())
                 .Returns(evidence);
 
@@ -199,7 +195,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilder_VerifyUrl()
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetEndpoint("/json")
                 .Build();
             
@@ -234,7 +230,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilder_VerifyParameters(string userAgent, string lat, string lon)
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetEndpoint("/json")
                 .Build();
 
@@ -286,7 +282,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilderElement_Promise(ExceptionType exceptionThrownByPromiseProperty, bool exceptionExpected)
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory).Build();
+                new JavaScriptBuilderElementBuilder(LoggerFactory).Build();
 
             var flowData = new Mock<IFlowData>();
             Configure(flowData);
@@ -368,7 +364,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilderElement_DelayExecution(bool minify)
         {
             _javaScriptBuilderElement = 
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetMinify(minify)
                 .Build();
             
@@ -419,7 +415,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         public void JavaScriptBuilder_VerifyObjName()
         {
             _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                new JavaScriptBuilderElementBuilder(LoggerFactory)
                 .SetEndpoint("/json")
                 .Build();
 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
@@ -22,28 +22,20 @@
 
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.TypedMap;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using FiftyOne.Pipeline.JsonBuilder.Data;
 using FiftyOne.Pipeline.JavaScriptBuilder.Data;
 using FiftyOne.Pipeline.JsonBuilder.FlowElement;
 using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
-using System;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
 using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Core.Exceptions;
-using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium;
-using System.Net.Http;
 using FiftyOne.Pipeline.Engines.TestHelpers;
-using System.Threading;
 using System.Net;
-using System.Threading.Tasks;
-using System.Text;
 
 namespace FiftyOne.Pipeline.JavaScript.Tests
 {
@@ -52,75 +44,38 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
     /// include using WebDrivers to simulate a browser environment.
     /// </summary>
     [TestClass]
-    public class JavaScriptBuilderElementTests
+    public class JavaScriptBuilderElementTests: JavaScriptBuilderElementTestsBase
     {
-        private Mock<IJsonBuilderElement> _mockjsonBuilderElement;
-        private Mock<IElementData> _elementDataMock;
         private ILoggerFactory _loggerFactory;
         private JavaScriptBuilderElement _javaScriptBuilderElement;
-        private IList<IElementPropertyMetaData> _elementPropertyMetaDatas;
 
-        private ChromeDriver _driver;
-        private INetwork _interceptor => _driver?.Manage().Network;
         private HttpClient httpClient;
-        private string ClientServerUrl;
         private CancellationTokenSource clientServerTokenSource;
-        private HttpListener clientServer;
-
-        private Action<NetworkRequestSentEventArgs> _onRequestSent = null;
+        private HttpListener _clientServer;
 
         /// <summary>
         /// Initialise the test.
         /// </summary>
         [TestInitialize]
-        public async Task Init()
+        public override async Task Init()
         {
             httpClient = new HttpClient();
 
+            await base.Init();
+
             // Start the client server
-            ClientServerUrl = $"http://localhost:{TestHttpListener.GetRandomUnusedPort()}/";
             clientServerTokenSource = new CancellationTokenSource();
             var token = clientServerTokenSource.Token;
             // We need the context of a page to be able to test the JavaScript 
             // correctly so create a simple HttpListener which serves some 
             // static HTML.
-            clientServer = TestHttpListener.SimpleListener(ClientServerUrl, token);
-
-            var chromeOptions = new ChromeOptions();
-            chromeOptions.AcceptInsecureCertificates = true;
-            // run in headless mode.
-            chromeOptions.AddArgument("--headless");
-            try
-            {
-                _driver = new ChromeDriver(chromeOptions);
-            }
-            catch (WebDriverException)
-            {
-                Assert.Inconclusive("Could not create a ChromeDriver, check " +
-                    "that the Chromium driver is installed");
-            }
-
-            _interceptor.NetworkRequestSent += OnNetworkRequestSent;
-            await _interceptor.StartMonitoring();
+            _clientServer = TestHttpListener.SimpleListener(ClientServerUrl, token);
 
             // Navigate to the client site.
-            _driver.Navigate().GoToUrl(ClientServerUrl);
+            Driver.Navigate().GoToUrl(ClientServerUrl);
 
-            _mockjsonBuilderElement = new Mock<IJsonBuilderElement>();
-
-            _elementPropertyMetaDatas = new List<IElementPropertyMetaData>() {
-                new ElementPropertyMetaData(_mockjsonBuilderElement.Object, "property", typeof(string), true)
-            };
-
-            _mockjsonBuilderElement.Setup(x => x.Properties).Returns(_elementPropertyMetaDatas);
             _loggerFactory = new LoggerFactory();
-
-            _elementDataMock = new Mock<IElementData>();
-            _elementDataMock.Setup(ed => ed.AsDictionary()).Returns(new Dictionary<string, object>() { { "property", "thisIsAValue" } });
         }
-
-        private void OnNetworkRequestSent(object sender, NetworkRequestSentEventArgs e)
-            => _onRequestSent?.Invoke(e);
 
         /// <summary>
         /// This method tests the accessors functionality of the JavaScript 
@@ -449,7 +404,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                     "Expected the generated JavaScript to contain the " +
                     "'getEvidencePropertiesFromObject' function but it does not.");
             }
-            IJavaScriptExecutor js = _driver;
+            IJavaScriptExecutor js = Driver;
             // Attempt to evaluate the JavaScript.
             js.ExecuteScript($"{result.JavaScript}; window.fod = fod;");
             var jsObject = js.ExecuteScript("return fod.sessionId;");
@@ -483,120 +438,11 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             _javaScriptBuilderElement.Process(flowData.Object);
 
-            IJavaScriptExecutor js = _driver;
+            IJavaScriptExecutor js = Driver;
 
             // Run the JavaScript content from the cloud service and bind to 
             // window so we can check it later.
             js.ExecuteScript($"{result.JavaScript}; window.testObj = testObj;");
-        }
-
-        private static string BuildXHRJS(string dstUrl, string method = "POST", string postData = "dummy", bool acceptJson = false)
-        {
-            StringBuilder s = new();
-            s.Append("xhr = new XMLHttpRequest();");
-            s.Append($"xhr.open('{method}', '{dstUrl}', true);");
-            if (acceptJson)
-            {
-                s.Append("xmlhttp.setRequestHeader(\"Accept\", \"application/json;charset=UTF-8\");");
-            }
-            s.Append($"xhr.send('{postData}');");
-            return s.ToString();
-        }
-            
-
-        [TestMethod]
-        public void JavaScriptBuilder_VerifyInterception()
-        {
-            bool testDone = false;
-            _onRequestSent = e => {
-                var p = e.RequestPostData;
-                testDone = true;
-            };
-            IJavaScriptExecutor js = _driver;
-            var q = js.ExecuteScript(BuildXHRJS($"{ClientServerUrl}/51dpipeline/json"));
-            Assert.IsTrue(testDone);
-        }
-
-        [TestMethod]
-        //[Timeout(20000)]
-        public void JavaScriptBuilder_ValidateSetCookieBlockCall()
-        {
-            string propName = "javascriptalpha";
-            string propCode = "// begin\ndocument.cookie = \"51D_alpha=\" + 42;\nalpha_set = true;\n// end\n";
-            string testCode = "alpha_set";
-
-            JObject jsonData = new() {
-                { "device", new JObject { { propName, propCode } } },
-                { "javascriptProperties", new JArray { $"device.{propName}" } },
-            };
-
-            int firstColon = ClientServerUrl.IndexOf(":");
-            _javaScriptBuilderElement =
-                new JavaScriptBuilderElementBuilder(_loggerFactory)
-                .SetMinify(false)
-                .SetProtocol(ClientServerUrl.Substring(0, firstColon))
-                .SetHost(ClientServerUrl.Substring(firstColon + 3))
-                .Build();
-            var flowData = new Mock<IFlowData>();
-            Configure(flowData, jsonData);
-
-            IJavaScriptBuilderElementData result = null;
-            flowData.Setup(d => d.GetOrAdd(
-                It.IsAny<ITypedKey<IJavaScriptBuilderElementData>>(),
-                It.IsAny<Func<IPipeline, IJavaScriptBuilderElementData>>()))
-                .Returns<ITypedKey<IJavaScriptBuilderElementData>, Func<IPipeline, IJavaScriptBuilderElementData>>((k, f) =>
-                {
-                    result = f(flowData.Object.Pipeline);
-                    return result;
-                });
-
-            _javaScriptBuilderElement.Process(flowData.Object);
-
-            // JS aquired, now test
-
-            string postData = null;
-            bool completed = false;
-            _onRequestSent = e =>
-            {
-                if (e.RequestUrl.EndsWith("json"))
-                {
-                    postData = e.RequestPostData;
-                }
-                if (e.RequestUrl.EndsWith("completed"))
-                {
-                    completed = true;
-                }
-            };
-            string additionalCode
-                = "; fod.complete(function (data) { "
-                + BuildXHRJS($"{ClientServerUrl}/51dpipeline/completed")
-                + " });";
-
-            IJavaScriptExecutor js = _driver;
-            js.ExecuteScript(result.JavaScript + additionalCode);
-
-            Assert.IsNotNull(postData);
-
-            while(!completed)
-            {
-                bool hrPrinted = false;
-                var entries = _driver.Manage().Logs.GetLog(LogType.Browser);
-                foreach (var entry in entries)
-                {
-                    if (!hrPrinted)
-                    {
-                        Console.WriteLine("----- ----- -----");
-                        hrPrinted = true;
-                    }
-                    Console.WriteLine(entry.ToString());
-                }
-                Thread.Sleep(1000);
-            }
-
-            var controlResult = js.ExecuteScript(testCode);
-            Assert.IsNotNull(controlResult);
-            Assert.IsInstanceOfType<bool>(controlResult);
-            Assert.IsTrue((bool)controlResult);
         }
 
 
@@ -610,7 +456,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         /// <returns></returns>
         private bool IsValidFodObject(string javaScript, string key, string property, object value)
         {
-            IJavaScriptExecutor js = _driver;
+            IJavaScriptExecutor js = Driver;
 
             // Run the JavaScript content from the cloud service and bind to 
             // window so we can check it later.
@@ -624,120 +470,23 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
                 return false;
         }
 
-        delegate void GetValueCallback(string key, out object result);
-
-        /// <summary>
-        /// Configure the flow data to respond in the way we want for 
-        /// this test.
-        /// </summary>
-        /// <param name="flowData">
-        /// The mock flow data instance to configure 
-        /// </param>
-        /// <param name="jsonData">
-        /// The JSON data to embed in the flow data.
-        /// This will be copied into the JavaScript that is produced.
-        /// </param>
-        /// <param name="hostName">
-        /// The host name to add to the evidence.
-        /// The JavaScriptBuilder should use this to generate the 
-        /// callback URL.
-        /// </param>
-        /// <param name="protocol">
-        /// The protocol to add to the evidence.
-        /// The JavaScriptBuilder should use this to generate the 
-        /// callback URL.
-        /// </param>
-        /// <param name="userAgent">
-        /// The User-Agent to add to the evidence.
-        /// </param>
-        /// <param name="latitude">
-        /// The latitude to add to the evidence.
-        /// </param>
-        /// <param name="longitude">
-        /// The longitude to add to the evidence.
-        /// </param>
-        private void Configure(
-            Mock<IFlowData> flowData,
-            JObject jsonData = null,
-            string hostName = "localhost",
-            string protocol = "https",
-            string userAgent = "iPhone",
-            string latitude = "51",
-            string longitude = "-1",
-            string jsObjName = null)
-        {
-            if (jsonData == null)
-            {
-                jsonData = new JObject();
-                jsonData["device"] = new JObject(new JProperty("ismobile", true));
-            }
-
-            flowData.Setup(d => d.Get<IJsonBuilderElementData>()).Returns(() =>
-            {
-                var d = new JsonBuilderElementData(new Mock<ILogger<JsonBuilderElementData>>().Object, flowData.Object.Pipeline);
-                d.Json = jsonData.ToString();
-                return d;
-            });
-
-            string session = "abcdefg-hijklmn-opqrst-uvwxyz";
-            int sequence = 1;
-            // Setup the TryGetEvidence methods that are used to get 
-            // host and protocol for the callback URL
-            flowData.Setup(d => d.TryGetEvidence(JavaScriptBuilder.Constants.EVIDENCE_HOST_KEY, out It.Ref<object>.IsAny))
-                .Callback(new GetValueCallback((string key, out object result) => { result = hostName; })).Returns(true);
-            flowData.Setup(d => d.TryGetEvidence(Core.Constants.EVIDENCE_PROTOCOL, out It.Ref<object>.IsAny))
-                .Callback(new GetValueCallback((string key, out object result) => { result = protocol; })).Returns(true);
-            flowData.Setup(d => d.TryGetEvidence(Engines.FiftyOne.Constants.EVIDENCE_SESSIONID, out It.Ref<object>.IsAny))
-                .Callback(new GetValueCallback((string key, out object result) => { result = session; })).Returns(true);
-            flowData.Setup(d => d.TryGetEvidence(Engines.FiftyOne.Constants.EVIDENCE_SEQUENCE, out It.Ref<object>.IsAny))
-                .Callback(new GetValueCallback((string key, out object result) => { result = sequence; })).Returns(true);
-
-            flowData.Setup(d => d.GetAsString(It.IsAny<string>())).Returns("None");
-            var evidenceDict = new Dictionary<string, object>() {
-                { JavaScriptBuilder.Constants.EVIDENCE_HOST_KEY, hostName },
-                { Core.Constants.EVIDENCE_PROTOCOL, protocol },
-                { Core.Constants.EVIDENCE_QUERY_USERAGENT_KEY, userAgent },
-                { "query.latitude", latitude },
-                { "query.longitude", longitude },
-                { Engines.FiftyOne.Constants.EVIDENCE_SEQUENCE, sequence },
-                { Engines.FiftyOne.Constants.EVIDENCE_SESSIONID, session }
-            };
-            if (jsObjName != null)
-            {
-                flowData.Setup(d => d.TryGetEvidence(JavaScriptBuilder.Constants.EVIDENCE_OBJECT_NAME, out It.Ref<object>.IsAny))
-                    .Callback(new GetValueCallback((string key, out object result) => { result = jsObjName; })).Returns(true);
-                evidenceDict.Add(JavaScriptBuilder.Constants.EVIDENCE_OBJECT_NAME, jsObjName);
-            }
-
-            flowData.Setup(d => d.GetEvidence().AsDictionary()).Returns(evidenceDict);
-            flowData.Setup(d => d.Get(It.IsAny<string>())).Returns(_elementDataMock.Object);
-
-
-        }
-
         /// <summary>
         /// Cleanup the RemoteWebDriver and http listener.
         /// </summary>
         [TestCleanup]
-        public async Task Cleanup()
+        public override async Task Cleanup()
         {
-            if (_driver != null)
-            {
-                await _interceptor.StopMonitoring();
-                _driver.Quit();
-            }
+            await base.Cleanup();
 
             // Stop the client server.
             clientServerTokenSource.Cancel();
-            while (clientServer.IsListening)
+            while (_clientServer.IsListening)
             {
-                clientServer.Stop();
+                _clientServer.Stop();
                 Thread.Sleep(1000);
             }
             // Close the listener
-            clientServer.Close();
-            // Ignore request monitoring events
-            _onRequestSent = null;
+            _clientServer.Close();
         }
     }
 }

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
@@ -6,7 +6,6 @@ using FiftyOne.Pipeline.Core.Data;
 using Moq;
 using Newtonsoft.Json.Linq;
 using FiftyOne.Pipeline.JsonBuilder.FlowElement;
-using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
 using FiftyOne.Pipeline.JsonBuilder.Data;
 
 namespace FiftyOne.Pipeline.JavaScript.Tests
@@ -17,6 +16,8 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
         public ChromeDriver Driver { get; private set; }
         public INetwork Interceptor => Driver?.Manage().Network;
+
+        public ILoggerFactory LoggerFactory { get; private set; }
 
 
         private Mock<IJsonBuilderElement> _mockjsonBuilderElement;
@@ -30,6 +31,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             ClientServerUrl = $"http://localhost:{TestHttpListener.GetRandomUnusedPort()}/";
 
             var chromeOptions = new ChromeOptions();
+            chromeOptions.SetLoggingPreference(LogType.Browser, OpenQA.Selenium.LogLevel.Info);
             chromeOptions.AcceptInsecureCertificates = true;
             // run in headless mode.
             chromeOptions.AddArgument("--headless");
@@ -56,6 +58,8 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
             _elementDataMock = new Mock<IElementData>();
             _elementDataMock.Setup(ed => ed.AsDictionary()).Returns(new Dictionary<string, object>() { { "property", "thisIsAValue" } });
+
+            LoggerFactory = new LoggerFactory();
         }
 
         private void OnNetworkRequestSent(object sender, NetworkRequestSentEventArgs e)

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium;
+using FiftyOne.Pipeline.Engines.TestHelpers;
+using FiftyOne.Pipeline.Core.Data;
+using Moq;
+using Newtonsoft.Json.Linq;
+using FiftyOne.Pipeline.JsonBuilder.FlowElement;
+using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
+using FiftyOne.Pipeline.JsonBuilder.Data;
+
+namespace FiftyOne.Pipeline.JavaScript.Tests
+{
+    public class JavaScriptBuilderElementTestsBase
+    {
+        public string ClientServerUrl { get; private set; }
+
+        public ChromeDriver Driver { get; private set; }
+        public INetwork Interceptor => Driver?.Manage().Network;
+
+
+        private Mock<IJsonBuilderElement> _mockjsonBuilderElement;
+        private Mock<IElementData> _elementDataMock;
+        private IList<IElementPropertyMetaData> _elementPropertyMetaDatas;
+
+        public Action<NetworkRequestSentEventArgs> OnRequestSent { get; set; } = null;
+
+        public virtual async Task Init()
+        {
+            ClientServerUrl = $"http://localhost:{TestHttpListener.GetRandomUnusedPort()}/";
+
+            var chromeOptions = new ChromeOptions();
+            chromeOptions.AcceptInsecureCertificates = true;
+            // run in headless mode.
+            chromeOptions.AddArgument("--headless");
+            try
+            {
+                Driver = new ChromeDriver(chromeOptions);
+            }
+            catch (WebDriverException)
+            {
+                Assert.Inconclusive("Could not create a ChromeDriver, check " +
+                    "that the Chromium driver is installed");
+            }
+
+            Interceptor.NetworkRequestSent += OnNetworkRequestSent;
+            await Interceptor.StartMonitoring();
+
+            _mockjsonBuilderElement = new Mock<IJsonBuilderElement>();
+
+            _elementPropertyMetaDatas = new List<IElementPropertyMetaData>() {
+                new ElementPropertyMetaData(_mockjsonBuilderElement.Object, "property", typeof(string), true)
+            };
+
+            _mockjsonBuilderElement.Setup(x => x.Properties).Returns(_elementPropertyMetaDatas);
+
+            _elementDataMock = new Mock<IElementData>();
+            _elementDataMock.Setup(ed => ed.AsDictionary()).Returns(new Dictionary<string, object>() { { "property", "thisIsAValue" } });
+        }
+
+        private void OnNetworkRequestSent(object sender, NetworkRequestSentEventArgs e)
+            => OnRequestSent?.Invoke(e);
+
+
+        delegate void GetValueCallback(string key, out object result);
+
+        /// <summary>
+        /// Configure the flow data to respond in the way we want for 
+        /// this test.
+        /// </summary>
+        /// <param name="flowData">
+        /// The mock flow data instance to configure 
+        /// </param>
+        /// <param name="jsonData">
+        /// The JSON data to embed in the flow data.
+        /// This will be copied into the JavaScript that is produced.
+        /// </param>
+        /// <param name="hostName">
+        /// The host name to add to the evidence.
+        /// The JavaScriptBuilder should use this to generate the 
+        /// callback URL.
+        /// </param>
+        /// <param name="protocol">
+        /// The protocol to add to the evidence.
+        /// The JavaScriptBuilder should use this to generate the 
+        /// callback URL.
+        /// </param>
+        /// <param name="userAgent">
+        /// The User-Agent to add to the evidence.
+        /// </param>
+        /// <param name="latitude">
+        /// The latitude to add to the evidence.
+        /// </param>
+        /// <param name="longitude">
+        /// The longitude to add to the evidence.
+        /// </param>
+        public void Configure(
+            Mock<IFlowData> flowData,
+            JObject jsonData = null,
+            string hostName = "localhost",
+            string protocol = "https",
+            string userAgent = "iPhone",
+            string latitude = "51",
+            string longitude = "-1",
+            string jsObjName = null)
+        {
+            if (jsonData == null)
+            {
+                jsonData = new JObject();
+                jsonData["device"] = new JObject(new JProperty("ismobile", true));
+            }
+
+            flowData.Setup(d => d.Get<IJsonBuilderElementData>()).Returns(() =>
+            {
+                var d = new JsonBuilderElementData(new Mock<ILogger<JsonBuilderElementData>>().Object, flowData.Object.Pipeline);
+                d.Json = jsonData.ToString();
+                return d;
+            });
+
+            string session = "abcdefg-hijklmn-opqrst-uvwxyz";
+            int sequence = 1;
+            // Setup the TryGetEvidence methods that are used to get 
+            // host and protocol for the callback URL
+            flowData.Setup(d => d.TryGetEvidence(JavaScriptBuilder.Constants.EVIDENCE_HOST_KEY, out It.Ref<object>.IsAny))
+                .Callback(new GetValueCallback((string key, out object result) => { result = hostName; })).Returns(true);
+            flowData.Setup(d => d.TryGetEvidence(Core.Constants.EVIDENCE_PROTOCOL, out It.Ref<object>.IsAny))
+                .Callback(new GetValueCallback((string key, out object result) => { result = protocol; })).Returns(true);
+            flowData.Setup(d => d.TryGetEvidence(Engines.FiftyOne.Constants.EVIDENCE_SESSIONID, out It.Ref<object>.IsAny))
+                .Callback(new GetValueCallback((string key, out object result) => { result = session; })).Returns(true);
+            flowData.Setup(d => d.TryGetEvidence(Engines.FiftyOne.Constants.EVIDENCE_SEQUENCE, out It.Ref<object>.IsAny))
+                .Callback(new GetValueCallback((string key, out object result) => { result = sequence; })).Returns(true);
+
+            flowData.Setup(d => d.GetAsString(It.IsAny<string>())).Returns("None");
+            var evidenceDict = new Dictionary<string, object>() {
+                { JavaScriptBuilder.Constants.EVIDENCE_HOST_KEY, hostName },
+                { Core.Constants.EVIDENCE_PROTOCOL, protocol },
+                { Core.Constants.EVIDENCE_QUERY_USERAGENT_KEY, userAgent },
+                { "query.latitude", latitude },
+                { "query.longitude", longitude },
+                { Engines.FiftyOne.Constants.EVIDENCE_SEQUENCE, sequence },
+                { Engines.FiftyOne.Constants.EVIDENCE_SESSIONID, session }
+            };
+            if (jsObjName != null)
+            {
+                flowData.Setup(d => d.TryGetEvidence(JavaScriptBuilder.Constants.EVIDENCE_OBJECT_NAME, out It.Ref<object>.IsAny))
+                    .Callback(new GetValueCallback((string key, out object result) => { result = jsObjName; })).Returns(true);
+                evidenceDict.Add(JavaScriptBuilder.Constants.EVIDENCE_OBJECT_NAME, jsObjName);
+            }
+
+            flowData.Setup(d => d.GetEvidence().AsDictionary()).Returns(evidenceDict);
+            flowData.Setup(d => d.Get(It.IsAny<string>())).Returns(_elementDataMock.Object);
+        }
+
+        public virtual async Task Cleanup()
+        {
+            if (Driver != null)
+            {
+                await Interceptor.StopMonitoring();
+                Driver.Quit();
+            }
+
+            // Ignore request monitoring events
+            OnRequestSent = null;
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Engines.TestHelpers/TestHttpServer.cs
+++ b/FiftyOne.Pipeline.Engines.TestHelpers/TestHttpServer.cs
@@ -103,6 +103,7 @@ namespace FiftyOne.Pipeline.Engines.TestHelpers
                 resp.ContentType = "text/html";
                 resp.ContentEncoding = Encoding.UTF8;
                 resp.ContentLength64 = data.LongLength;
+                resp.AddHeader("Access-Control-Allow-Origin", "*");
 
                 // Write out to the response stream (asynchronously), then close it
                 await resp.OutputStream.WriteAsync(data, 0, data.Length);


### PR DESCRIPTION
### Changes

- Move `FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj` to .NET 8.0 (enable Minimal API usage).
- Add `Access-Control-Allow-Origin: *` header to `TestHttpServer`'s responses.
- Split up `JavaScriptBuilderElementTests` class to introduce parent `JavaScriptBuilderElementTestsBase`.
- Add new test class `JavaScriptBuilderElementTemplateTests`.

### The flow of new test

- 🛠️ Build new JSON with JavaScript snippet property.
- 🛠️ Visit the page.
  - 🗒️ Script invokes the snippet code.
- ❔ Observe POST data when script calls `json` endpoint. Check the data set by snippet is present.
- ❔ Check for `complete` callback by the script.
- ❔ Check the snippet was called by testing a flag in `window`.
- 🛠️ Replace a JSON with another JavaScript snippet property.
- 🛠️ Add new cookie.
- 🛠️ Reload the page.
  - 🗒️ Script invokes the new snippet code.
  - 🗒️ Script might migrate extra cookie to local storage
- ❔ Observe POST data when script calls `json` endpoint. Check all 3 data pieces (persisted old + new + extra) are present.
- ❔ Check for `complete` callback by the script.
- ❔ Check the new snippet was called by testing a flag in `window`.
- ❔ Check the old snippet was not called again by testing a flag in `window`.
- ❔ [Inconclusive] Check no cookies are set.

### Why?

- https://github.com/postindustria-tech/51degrees-issues/issues/48